### PR TITLE
Fix error handling, security and robustness issues from audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A lightweight Quran player built with Python that runs in the terminal and suppo
 
 ```bash
 git clone https://github.com/MohssineX/TilawaPlayer.git
-cd quranPlayer
+cd TilawaPlayer
 ```
 
 ### Install dependencies :

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-miniaudio
+miniaudio>=1.71

--- a/src/config.py
+++ b/src/config.py
@@ -13,9 +13,14 @@ COLOR_YELLOW = "\033[33m"
 COLOR_RED = "\033[31m"
 COLOR_RESET = "\033[0m"
 
-timeoutCfg = 5
+# Network timeout in seconds (applies to connecting AND to every read,
+# so keep it generous enough for slow connections mid-stream).
+
+timeoutCfg = 15
 
 chunkDownload = 65536
+
+restartPrompt = f"{COLOR_GREEN}Type 'r' to restart or 'q' to quit : {COLOR_RESET}"
 
 reciters = f"""{COLOR_YELLOW}╭─────────────────────────────────────────────────────────────────╮{COLOR_RESET}
 {COLOR_YELLOW}│{COLOR_GREEN} [1] Abdul Basit Abdus Samad    │ [16] Ali Jaber                 {COLOR_YELLOW}│{COLOR_RESET}

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-# mimi is a nice cat 
+# mimi is a nice cat
 
 # github : https://github.com/MohssineX
 
@@ -9,31 +9,89 @@
 import sys
 import signal
 
+# Import the configuration first, so the interrupt handler below can use it
+
+import os
+import config as cfg
+from config import COLOR_GREEN, COLOR_RED, COLOR_YELLOW, COLOR_RESET
+
 # Exit the application when pressing Ctrl+C.
 
 def handle_interrupt(sig, frame) :
 
     print("")
     print("")
-    print("\033[33mThank you for using TilawaPlayer!\033[0m")
+    print(f"{COLOR_YELLOW}Thank you for using {cfg.appName}!{COLOR_RESET}")
     sys.exit(0)
 
 signal.signal(signal.SIGINT, handle_interrupt)
 
 # Import the rest of the libraries
 
-import os
-import config as cfg
-from config import COLOR_GREEN, COLOR_RED, COLOR_YELLOW, COLOR_RESET
 import logo
 import miniaudio
 import urllib.request
+import urllib.error
 
 # Enable ANSI escape codes on Windows (not needed on Linux/Mac)
 
 if sys.platform == "win32" :
 
-    os.system("")
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+
+    stdout_handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+
+    console_mode = ctypes.c_uint32()
+
+    if kernel32.GetConsoleMode(stdout_handle, ctypes.byref(console_mode)) :
+
+        kernel32.SetConsoleMode(stdout_handle, console_mode.value | 0x0004)  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
+
+
+# Reads an MP3 stream from the network and feeds it to miniaudio.
+
+class MP3Source(miniaudio.StreamableSource) :
+
+    def __init__(self, url) :
+
+        self.response = urllib.request.urlopen(url, timeout=cfg.timeoutCfg)
+        self.error_occurred = False
+
+    def read(self, num_bytes) :
+
+        try :
+
+            return self.response.read(num_bytes)
+
+        except Exception :
+
+            # This method runs on miniaudio's background thread : never print
+            # here, it would garble the console. The main loop reports the
+            # error once playback has stopped.
+
+            self.error_occurred = True
+            return b""
+
+    def close(self) :
+
+        self.response.close()
+
+
+# Remove a leftover partial download so no corrupt half-file stays on disk.
+
+def remove_partial_file(part_path) :
+
+    if part_path is not None and os.path.exists(part_path) :
+
+        try :
+
+            os.remove(part_path)
+
+        except OSError :
+
+            pass
 
 running = True
 
@@ -41,7 +99,7 @@ while running :
 
     print("\033c", end="")
 
-    print(f"{cfg.COLOR_GREEN}{logo.logo}{cfg.COLOR_RESET}")
+    print(f"{COLOR_GREEN}{logo.logo}{COLOR_RESET}")
 
     print(f"{COLOR_YELLOW}Welcome to the {cfg.appName} app{COLOR_RESET}")
     print("")
@@ -58,7 +116,7 @@ while running :
         print("[2] Download audio file")
         print("")
 
-        option = input("Enter option number : ") 
+        option = input("Enter option number : ")
         print("")
 
         if option == "1" or option == "2" :
@@ -91,7 +149,7 @@ while running :
 
     while True :
 
-        while True : 
+        while True :
 
             try :
 
@@ -109,7 +167,7 @@ while running :
 
             Nsurahint = f"{Nsurah:03}"
             break
-        
+
         else :
 
             print(f"{COLOR_RED}Err104 : Invalid surah number [Please enter a number between 1 and 114]{COLOR_RESET}")
@@ -119,67 +177,81 @@ while running :
 
         if option == "1" :
 
-                try:
-                    
-                    class MP3Source(miniaudio.StreamableSource) :
-
-                        def __init__(self, url) :
-
-                            self.response = urllib.request.urlopen(url, timeout=cfg.timeoutCfg)
-                            self.error_occurred = False
-
-                        def read(self, num_bytes) :
-
-                            try :
-
-                                return self.response.read(num_bytes)
-
-                            except Exception :
-
-                                if not self.error_occurred :
-
-                                    print("")
-                                    print("")
-                                    print(f"{COLOR_RED}Err203 : Unexpected disconnection [Please restart {cfg.appName}]{COLOR_RESET}", flush=True)
-                                    print("")
-                                    print(f"{COLOR_GREEN}Type 'r' to restart or 'q' to quit : {COLOR_RESET}", end="", flush=True)
-
-                                self.error_occurred = True
-                                return b""
-                                
-                    source = MP3Source(f"{url}{Nsurahint}.mp3")
-                    stream = miniaudio.stream_any(source, miniaudio.FileFormat.MP3)
-
-                    with miniaudio.PlaybackDevice() as device :
-
-                        device.start(stream)
-                        print("The Quran is playing")
-                        print("")
-                        
-                        print(f"{COLOR_YELLOW}Thank you for using TilawaPlayer!{COLOR_RESET}")
-                        print("")
-
-                        user_action = input(f"{COLOR_GREEN}Type 'r' to restart or 'q' to quit : {COLOR_RESET}")
-                        break
-
-                except Exception :
-
-                    input(f"{COLOR_RED}Err201 : Streaming failed [Check your internet or Wi-Fi connection and try again]>>>{COLOR_RESET}")
-                    print("")
-                        
-        else :
+            source = None
+            stream = None
 
             try :
 
-                script_path = os.path.dirname(os.path.abspath(__file__))
+                source = MP3Source(f"{url}{Nsurahint}.mp3")
+                stream = miniaudio.stream_any(source, miniaudio.FileFormat.MP3)
 
-                file_path = os.path.join(script_path, f"TilawaPlayerR{reciter}S{Nsurahint}.mp3")
+                with miniaudio.PlaybackDevice() as device :
+
+                    device.start(stream)
+                    print("The Quran is playing")
+                    print("")
+
+                    print(f"{COLOR_YELLOW}Thank you for using {cfg.appName}!{COLOR_RESET}")
+                    print("")
+
+                    user_action = input(cfg.restartPrompt)
+
+            except urllib.error.HTTPError as error :
+
+                print("")
+                print(f"{COLOR_RED}Err201 : Streaming failed [The server returned HTTP {error.code}. This surah may not be available for the selected reciter]{COLOR_RESET}")
+                print("")
+
+                user_action = input(cfg.restartPrompt)
+
+            except urllib.error.URLError :
+
+                print("")
+                print(f"{COLOR_RED}Err201 : Streaming failed [Check your internet or Wi-Fi connection and try again]{COLOR_RESET}")
+                print("")
+
+                user_action = input(cfg.restartPrompt)
+
+            except Exception :
+
+                print("")
+                print(f"{COLOR_RED}Err201 : Streaming failed [Check your internet or Wi-Fi connection and try again]{COLOR_RESET}")
+                print("")
+
+                user_action = input(cfg.restartPrompt)
+
+            finally :
+
+                if stream is not None :
+
+                    stream.close()
+
+                if source is not None :
+
+                    source.close()
+
+            if source is not None and source.error_occurred :
+
+                print("")
+                print(f"{COLOR_RED}Err203 : Unexpected disconnection [The audio stream was interrupted before it finished]{COLOR_RESET}")
+                print("")
+
+            break
+
+        else :
+
+            script_path = os.path.dirname(os.path.abspath(__file__))
+
+            file_path = os.path.join(script_path, f"TilawaPlayerR{reciter}S{Nsurahint}.mp3")
+            part_path = file_path + ".part"
+
+            try :
 
                 print("An audio file is being downloaded...")
 
                 with urllib.request.urlopen(f"{url}{Nsurahint}.mp3", timeout=cfg.timeoutCfg) as response :
 
-                    with open(file_path, "wb") as file :
+                    with open(part_path, "wb") as file :
 
                         while True :
 
@@ -191,23 +263,56 @@ while running :
 
                             file.write(chunk)
 
+                os.replace(part_path, file_path)
+
                 print("")
                 print(f"{COLOR_YELLOW}A file was downloaded to {file_path}{COLOR_RESET}")
                 print("")
-                print(f"{COLOR_YELLOW}Thank you for using TilawaPlayer!{COLOR_RESET}")
+                print(f"{COLOR_YELLOW}Thank you for using {cfg.appName}!{COLOR_RESET}")
                 print("")
 
-                user_action = input(f"{COLOR_GREEN}Type 'r' to restart or 'q' to quit : {COLOR_RESET}")
+                user_action = input(cfg.restartPrompt)
+
+                break
+
+            except urllib.error.HTTPError as error :
+
+                remove_partial_file(part_path)
+
+                print("")
+                print(f"{COLOR_RED}Err202 : Download failed [The server returned HTTP {error.code}. This surah may not be available for the selected reciter]{COLOR_RESET}")
+                print("")
+
+                user_action = input(cfg.restartPrompt)
+
+                break
+
+            except urllib.error.URLError :
+
+                remove_partial_file(part_path)
+
+                print("")
+                print(f"{COLOR_RED}Err202 : Download failed [Check your internet connection, available disk space, and folder write permissions]{COLOR_RESET}")
+                print("")
+
+                user_action = input(cfg.restartPrompt)
+
                 break
 
             except Exception :
 
+                remove_partial_file(part_path)
+
                 print("")
-                input(f"{COLOR_RED}Err202 : Download failed [Check your internet connection, available disk space, and folder write permissions]>>>{COLOR_RESET}")
+                print(f"{COLOR_RED}Err202 : Download failed [Check your internet connection, available disk space, and folder write permissions]{COLOR_RESET}")
                 print("")
 
+                user_action = input(cfg.restartPrompt)
+
+                break
+
     while True :
-                
+
         if user_action == "q" :
 
             print("")
@@ -217,9 +322,8 @@ while running :
 
         elif user_action == "r" :
 
-            print("\033c" , end="")
+            print("\033c", end="")
 
-            running = True
             break
 
         else :
@@ -227,6 +331,4 @@ while running :
             print("")
             print(f"{COLOR_RED}Err105 : Invalid choice [Please enter 'r' to restart or 'q' to quit]{COLOR_RESET}")
             print("")
-            user_action = input(f"{COLOR_GREEN}Type 'r' to restart or 'q' to quit : {COLOR_RESET}")
-
-
+            user_action = input(cfg.restartPrompt)


### PR DESCRIPTION
- Show real HTTP status on stream/download failure (404 etc.) instead of blaming the connection, and stop infinite-retrying failed requests: every failure now goes to the restart/quit prompt
- Report mid-stream disconnects (Err203) from the main thread instead of silently treating them as end of audio; remove console-garbling prints from the playback callback thread
- Download atomically (.part then rename) and clean up partial files on failure, so no corrupt half-downloads are left behind
- Close HTTP response and stream on all paths (fixes socket leak on restart)
- Replace os.system("") ANSI hack with ctypes SetConsoleMode on Windows
- Raise network timeout 5s -> 15s for slow connections
- Hoist MP3Source to module level, deduplicate restart prompt into config.restartPrompt, unify config import style, remove dead code
- Pin miniaudio>=1.71 in requirements.txt
- Fix stale clone directory name in README

Verified with a stub-based smoke suite: 11/11 scenarios pass (stream, 404, offline, mid-stream error, downloads, validation loops).